### PR TITLE
Extend mutation operations to authors

### DIFF
--- a/apollo_server/src/resolvers.ts
+++ b/apollo_server/src/resolvers.ts
@@ -61,6 +61,28 @@ const resolvers = {
                 return game
             })
             return db.games.find((game) => game.id === args.id)
+        },
+        addAuthor(_parent, args) {
+            const newAuthor = {
+                ...args.author,
+                id: (db.authors.length + 1).toString()
+            }
+
+            db.authors.push(newAuthor);
+            return newAuthor;
+        },
+        deleteAuthor(_parent, args) {
+            db.authors = db.authors.filter((author) => author.id !== args.id);
+            return db.authors;
+        },
+        updateAuthor(_parent, args) {
+            db.authors = db.authors.map((author) => {
+                if (author.id === args.id) {
+                    return {...args.edits, ...author}
+                }
+                return author
+            })
+            return db.authors.find((author) => author.id === args.id)
         }
     }
 }

--- a/apollo_server/src/resolvers.ts
+++ b/apollo_server/src/resolvers.ts
@@ -78,7 +78,7 @@ const resolvers = {
         updateAuthor(_parent, args) {
             db.authors = db.authors.map((author) => {
                 if (author.id === args.id) {
-                    return {...args.edits, ...author}
+                    return {...author, ...args.edits}
                 }
                 return author
             })

--- a/apollo_server/src/schema.ts
+++ b/apollo_server/src/schema.ts
@@ -34,6 +34,9 @@ export const typeDefs = `#graphql
         addGame(game: AddGameInput!): Game
         deleteGame(id: ID!): [Game]
         updateGame(id: ID!, edits: UpdateGameInput!): Game
+        addAuthor(author: AddAuthorInput!): Author
+        deleteAuthor(id: ID!): [Author]
+        updateAuthor(id: ID!, edits: UpdateAuthorInput!): Author
     }
 
     input AddGameInput {
@@ -44,5 +47,15 @@ export const typeDefs = `#graphql
     input UpdateGameInput {
         title: String
         platform: [String!]
+    }
+
+    input AddAuthorInput {
+        name: String!
+        verified: Boolean!
+    }
+
+    input UpdateAuthorInput {
+        name: String
+        verified: Boolean
     }
 `;


### PR DESCRIPTION
Implement **ADD**, **DELETE** and **UPDATE** features for authors. On https://github.com/aantoniorodrigues/graphql_server/pull/6 the same was implemented, but only including games.

### ADD, DELETE and UPDATE author

<img width="1719" height="923" alt="Screenshot 2025-08-14 at 12 12 25" src="https://github.com/user-attachments/assets/613fb608-879d-472a-9a96-2723b0bf370d" />
<img width="1576" height="924" alt="Screenshot 2025-08-14 at 12 16 16" src="https://github.com/user-attachments/assets/c7d65f3b-6607-4473-866c-a8b51b94eb75" />
<img width="1578" height="923" alt="Screenshot 2025-08-14 at 12 16 43" src="https://github.com/user-attachments/assets/dcc10e53-acb1-4d00-9340-1cee2186c419" />
<img width="1579" height="922" alt="Screenshot 2025-08-14 at 12 17 10" src="https://github.com/user-attachments/assets/ef35f694-7cd5-4b81-a2a8-99937c6021a3" />

