### PR TITLE
Extend mutations for reviews

### DIFF
--- a/apollo_server/src/resolvers.ts
+++ b/apollo_server/src/resolvers.ts
@@ -83,6 +83,28 @@ const resolvers = {
                 return author
             })
             return db.authors.find((author) => author.id === args.id)
+        },
+        addReview(_parent, args) {
+            const newReview = {
+                ...args.review,
+                id: (db.reviews.length + 1).toString()
+            }
+
+            db.reviews.push(newReview);
+            return newReview;
+        },
+        deleteReview(_parent, args) {
+            db.reviews = db.reviews.filter((review) => review.id !== args.id);
+            return db.reviews;
+        },
+        updateReview(_parent, args) {
+            db.reviews = db.reviews.map((review) => {
+                if (review.id === args.id) {
+                    return {...review, ...args.edits}
+                }
+                return review
+            })
+            return db.reviews.find((review) => review.id === args.id)
         }
     }
 }

--- a/apollo_server/src/schema.ts
+++ b/apollo_server/src/schema.ts
@@ -37,6 +37,9 @@ export const typeDefs = `#graphql
         addAuthor(author: AddAuthorInput!): Author
         deleteAuthor(id: ID!): [Author]
         updateAuthor(id: ID!, edits: UpdateAuthorInput!): Author
+        addReview(review: AddReviewInput!): Review
+        deleteReview(id: ID!): [Review]
+        updateReview(id: ID!, edits: UpdateReviewInput!): Review
     }
 
     input AddGameInput {
@@ -53,9 +56,20 @@ export const typeDefs = `#graphql
         name: String!
         verified: Boolean!
     }
-
     input UpdateAuthorInput {
         name: String
         verified: Boolean
+    }
+
+    input AddReviewInput {
+        rating: Int!
+        content: String!
+        author_id: ID!
+        game_id: ID!         
+    }
+
+    input UpdateReviewInput {
+        rating: Int
+        content: String
     }
 `;


### PR DESCRIPTION
Implement **ADD**, **DELETE** and **UPDATE** features for reviews. On https://github.com/aantoniorodrigues/graphql_server/pull/6 and https://github.com/aantoniorodrigues/graphql_server/pull/7 the same was implemented for games and authors.

### ADD, DELETE and UPDATE review

<img width="1568" height="920" alt="Screenshot 2025-08-14 at 13 07 13" src="https://github.com/user-attachments/assets/15a52e3d-7fd9-4925-be9c-a269c321a38e" />
<img width="1568" height="921" alt="Screenshot 2025-08-14 at 13 08 35" src="https://github.com/user-attachments/assets/4f45ce88-0758-472a-8932-61c085159c16" />
<img width="1720" height="922" alt="Screenshot 2025-08-14 at 13 20 27" src="https://github.com/user-attachments/assets/80f20c9c-80e9-4faf-aaa1-abd37b4935af" />
<img width="1725" height="926" alt="Screenshot 2025-08-14 at 12 49 51" src="https://github.com/user-attachments/assets/5ad152b7-2292-4fee-8b58-6bed90dac697" />